### PR TITLE
Send the correct reload response message

### DIFF
--- a/ZombieBot1.0.py
+++ b/ZombieBot1.0.py
@@ -165,11 +165,11 @@ class ZombieBot(irc.bot.SingleServerIRCBot):
     def handle_reloading(self, c, e):
         user = e.source.nick
         channel = e.target
-        self.bullets[user] = 5
         if self.bullets.get(user) == "exploded":
             c.privmsg(channel, f"{user}, your gun has been fixed and reloaded!")
         else:
             c.privmsg(channel, f"{user}, your gun is reloaded!")
+        self.bullets[user] = 5
 
     def print_scores(self, c, e):
         user = e.source.nick

--- a/ZombieBot2.0.py
+++ b/ZombieBot2.0.py
@@ -170,11 +170,11 @@ class ZombieBot(irc.bot.SingleServerIRCBot):
     def handle_reloading(self, c, e):
         user = e.source.nick
         channel = e.target
-        self.bullets[user] = 5
         if self.bullets.get(user) == "exploded":
             c.privmsg(channel, f"{user}, your gun has been fixed and reloaded!")
         else:
             c.privmsg(channel, f"{user}, your gun is reloaded!")
+        self.bullets[user] = 5
 
     def print_scores(self, c, e):
         channel = e.target


### PR DESCRIPTION
Because the `bullets` dictionary was updated before the `if` statement, the user's value would never be `"exploded"`. So I moved the assignment to happen after the `if`.